### PR TITLE
Change web.config to provide ability to run BotEngine without errors.…

### DIFF
--- a/BOTFirst/BOTFirst/Web.config
+++ b/BOTFirst/BOTFirst/Web.config
@@ -4,6 +4,16 @@
   http://go.microsoft.com/fwlink/?LinkId=301879
   -->
 <configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
   <appSettings>
     <!-- update these with your BotId, Microsoft App Id and your Microsoft App Password-->
     <add key="BotId" value="YourBotId" />
@@ -65,16 +75,6 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  </configSections>
-  <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
-    <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
-    </providers>
-  </entityFramework>
   <connectionStrings>
     <add name="EDModelContainer" connectionString="metadata=res://*/EDModel.csdl|res://*/EDModel.ssdl|res://*/EDModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=USEROK-ПК\SQLEXPRESS;initial catalog=achievementbotdb;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />
   </connectionStrings>


### PR DESCRIPTION
… In the previous run we had such errors: "Only one <configSections> element allowed. It must be the first child element of the root <configuration> element".